### PR TITLE
feat(treesitter): add injections of glsl

### DIFF
--- a/after/queries/lua/injections.scm
+++ b/after/queries/lua/injections.scm
@@ -1,0 +1,19 @@
+;; extends
+
+;; inject glsl for any string that starts `#pragma language glsl`
+(string 
+  content: _ @injection.content
+  (#lua-match? @injection.content "^%s*#pragma language glsl")
+  (#set! injection.language "glsl"))
+
+
+; inject glsl for calls to newShader
+; love.graphics.newShader([[...]])
+; and even just newShader([[...]])
+((function_call
+  name: (_) @_function
+  arguments: (arguments
+    (string
+      content: _ @injection.content)))
+  (#contains? @_function "newShader")
+  (#set! injection.language "glsl"))


### PR DESCRIPTION
Using treesitter language injections add support for inline glsl. Most notably it adds highlights, but actually more than that - for example plugin comment.nvim now comments (gcc) inside shader code using `//` string. And folding works + any other treesitter magic :)

Added queries in `after/queries/lua/injections.scm` as said [here](https://github.com/nvim-treesitter/nvim-treesitter?tab=readme-ov-file#adding-queries). And took [these](https://github.com/neovim/neovim/blob/master/runtime/queries/lua/injections.scm) from `nvim/runtime/queries` queries as starting point.

I'am not sure that this really helps anyone, but it looks cool :)

before
<img width="572" alt="Screenshot 2024-05-11 at 01 24 31" src="https://github.com/S1M0N38/love2d.nvim/assets/1163040/b1ad2bee-01ea-4f31-9637-37edc50c3316">

after
<img width="572" alt="Screenshot 2024-05-11 at 01 24 44" src="https://github.com/S1M0N38/love2d.nvim/assets/1163040/bc4a5edb-a7a6-46d8-80af-d7fc82c1a0f6">

There is two ways I check if glsl should be injected:
1. Calls to `love.graphics.newShader([[...]])`
2. Any string that starts with `#pragma language glsl`

There is 2 problems right now:
1. If plugin is lazy loaded, then you have to `:e` current file for treesitter to re-highlight injected code.
2. And you can see that variables in glsl (e.g. `time`) are highlighted in green, as lua strings. Highlight groups seems ok, but maybe I can fix it somehow

And I think maybe I should update readme. Because at least you need to install glsl parser to see this highlights (`:TSInstall glsl`)
