### PR TITLE
event = 'VeryLazy'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ However, I believe that providing this simple codebase to explore can be a good 
 -- using lazy.nvim
 {
   "S1M0N38/love2d.nvim",
+  event = 'VeryLazy',
   cmd = "LoveRun",
   opts = { },
   keys = {

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ However, I believe that providing this simple codebase to explore can be a good 
 -- using lazy.nvim
 {
   "S1M0N38/love2d.nvim",
-  event = 'VeryLazy',
-  cmd = "LoveRun",
+  event = "VeryLazy",
   opts = { },
   keys = {
     { "<leader>v", ft = "lua", desc = "LÖVE" },

--- a/doc/love2d.txt
+++ b/doc/love2d.txt
@@ -20,7 +20,7 @@ example, using `lazy.nvim`:
 >lua
   {
     "S1M0N38/love2d.nvim",
-    cmd = "LoveRun",
+    event = "VeryLazy",
     opts = { },
     keys = {
       { "<leader>v", desc = "LÖVE" },


### PR DESCRIPTION
This PR updates the plugin installation instructions to include event = 'VeryLazy' in the setup example.

Edit* Forgot to add, this may only happen in my specific scenario, tried with 2 kickstart nvim configs with lazyvim on 2 machines. But according to documentation help should just work, so if I'm wrong, dismiss this pr.

Why:

When the plugin is configured to load lazily via cmd or keys, Neovim does not add it to the runtimepath until it's explicitly triggered (e.g., by running :LoveRun). As a result, users who follow the current setup example won't have access to the plugin’s :help love2d documentation until after running one of the commands.

Adding event = 'VeryLazy' ensures that the plugin is loaded shortly after startup, without delaying Neovim’s launch, and makes the documentation immediately available via :help, even before any commands are used.

Who this helps:

Anyone who installs the plugin for the first time and expects :help love2d to work right away (like I did 😅) will benefit from this small but helpful change.