### PR TITLE
feat: add makeprg and errorformat autocommand setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -57,6 +57,9 @@ require("lazy.minit").repro({
         -- restart love2d when a file is saved
         -- restart_on_save = false,
         --
+        -- setup makeprg and errorformat for :make command (default: true)
+        -- setup_makeprg = true,
+        --
         -- Open a right split window logging debug messages from love2d
         -- debug_window_opts = {
         --   split = "right",
@@ -83,7 +86,7 @@ nvim -u repro.lua main.lua
 ```
 
 > [!TIP]
-> Alternatively, you can clone this repository, navigate to the `tests/game` directory and run `nvim -u repro.lua main.lua`*
+> Alternatively, you can clone this repository, navigate to the `tests/game` directory and run `nvim -u repro.lua main.lua`
 
 3. Reproduce the bug
 

--- a/doc/love2d.txt
+++ b/doc/love2d.txt
@@ -64,6 +64,7 @@ love2d.setup({opts}) ~
     path_to_love_bin = "love",
     restart_on_save = false,
     debug_window_opts = nil,
+    setup_makeprg = true,
     identify_love_projects = true
   }
 <
@@ -89,6 +90,11 @@ love2d.setup({opts}) ~
     }
   }
 <
+
+  - `setup_makeprg`: When true (default), automatically setup `makeprg` and
+    `errorformat` for LÖVE projects. This allows you to use `:make` to run
+    your LÖVE project and parse error messages to jump to the correct file
+    and line number when errors occur.
 
   - `identify_love_projects`: When true (default), the plugin will only
     initialize LSP support if it detects a LÖVE project. Detection works by

--- a/lua/love2d/config.lua
+++ b/lua/love2d/config.lua
@@ -4,12 +4,14 @@ config.defaults = {
   path_to_love_bin = "love",
   restart_on_save = false,
   debug_window_opts = nil,
+  setup_makeprg = true,
 }
 
 ---@class options
 ---@field path_to_love_bin? string: The path to the Love2D executable
 ---@field restart_on_save? boolean: Restart Love2D when a file is saved
 ---@field debug_window_opts? table: Create split window with Love2D terminal output
+---@field setup_makeprg? boolean: Setup makeprg and errorformat for Love2D projects
 config.options = {}
 
 ---Setup the LSP for love2d using vim.lsp.config with proper merging
@@ -46,6 +48,18 @@ local function setup_lsp()
   vim.lsp.enable({ "lua_ls" })
 end
 
+---Setup makeprg and errorformat for Love2D projects
+local function setup_makeprg_and_errorformat()
+  -- Set errorformat to parse Love2D error messages
+  vim.api.nvim_set_option_value(
+    "errorformat",
+    "Error:%*[^:]:\\ %f:%l:%m,Error:\\ %f:%l:%m,%f:%l:%m",
+    { scope = "local" }
+  )
+  -- Set makeprg to run Love2D on current directory
+  vim.api.nvim_set_option_value("makeprg", "love .", { scope = "local" })
+end
+
 ---Create auto commands for love2d:
 --- - Restart on save: Restart Love2D when a file is saved.
 local function create_auto_commands()
@@ -61,6 +75,19 @@ local function create_auto_commands()
           vim.defer_fn(function()
             love2d.run(path)
           end, 500)
+        end
+      end,
+    })
+  end
+
+  if config.options.setup_makeprg then
+    vim.api.nvim_create_autocmd("FileType", {
+      group = vim.api.nvim_create_augroup("love2d_makeprg_setup", { clear = true }),
+      pattern = "lua",
+      callback = function()
+        local love2d = require("love2d")
+        if love2d.is_love2d_project() then
+          setup_makeprg_and_errorformat()
         end
       end,
     })

--- a/tests/game/repro.lua
+++ b/tests/game/repro.lua
@@ -34,6 +34,9 @@ require("lazy.minit").repro({
         -- restart love2d when a file is saved
         -- restart_on_save = false,
         --
+        -- setup makeprg and errorformat for :make command (default: true)
+        -- setup_makeprg = true,
+        --
         -- Open a right split window logging debug messages from love2d
         -- debug_window_opts = {
         --   split = "right",


### PR DESCRIPTION
Add automatic setup of makeprg and errorformat for Love2D projects:
- New setup_makeprg config option (default: true)
- Auto-configures errorformat to parse Love2D error messages
- Sets makeprg to "love ." for :make command support
- Enables jump-to-error functionality in quickfix list
- Only activates in detected Love2D projects
- Follows existing plugin patterns and conventions