### PR TITLE
Support for emmylua_ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ However, I believe that providing this simple codebase to explore can be a good 
 
 - Neovim >= **0.11**
 - [LÖVE](https://www.love2d.org/)
-- [lua_ls](https://luals.github.io/), configured with
+- [lua_ls](https://luals.github.io/) or [emmylua_ls](https://github.com/EmmyLuaLs/emmylua-analyzer-rust), configured with
   - [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) or
   - using Neovim LSP built-in functions
 

--- a/doc/love2d.txt
+++ b/doc/love2d.txt
@@ -61,6 +61,7 @@ love2d.setup({opts}) ~
 
 >lua
   {
+    lua_language_server_provider = "lua_ls",
     path_to_love_bin = "love",
     restart_on_save = false,
     debug_window_opts = nil,
@@ -68,6 +69,10 @@ love2d.setup({opts}) ~
     identify_love_projects = true
   }
 <
+
+  - `lua_language_server_provider`: Choose what language server that
+    love2d.nvim should configure for. (currently available language servers
+    are `lua_ls` and `emmylua_ls`)
 
   - `path_to_love_bin`: The path to the `love` binary. If you have the `love`
     binary in your `PATH` you can leave this option empty. If you are using
@@ -132,13 +137,14 @@ Language Server Protocol (LSP) is the way to provide code completion, linting,
 formatting, and other language-specific features to your editor. So it
 effectively makes your editor smarter, enhancing your development experience.
 
-This plugin automatically configures `lua_ls` for LÖVE development when a LÖVE
-project is detected. It uses Neovim's built-in LSP configuration system
-(`vim.lsp.config`) available in Neovim 0.11+. The plugin will:
+This plugin automatically configures `lua_ls` (or `emmylua_ls`) for LÖVE 
+development when a LÖVE project is detected. It uses Neovim's built-in LSP 
+configuration system (`vim.lsp.config`) available in Neovim 0.11+. 
+The plugin will:
 
 - Configure Lua 5.1/LuaJIT runtime settings appropriate for LÖVE
 - Add bundled LÖVE and LuaSocket library definitions to the workspace
-- Merge with any existing `lua_ls` configuration you may have
+- Merge with any existing `lua_ls` (or `emmylua_ls`) configuration you may have
 - Only activate when `identify_love_projects` detects a LÖVE project
 
 For example, when placing the cursor over the `love` variable and pressing

--- a/lua/love2d/config.lua
+++ b/lua/love2d/config.lua
@@ -1,6 +1,7 @@
 local config = {}
 
 config.defaults = {
+  lua_language_server_provider = "lua_ls",
   path_to_love_bin = "love",
   restart_on_save = false,
   debug_window_opts = nil,
@@ -8,6 +9,7 @@ config.defaults = {
 }
 
 ---@class options
+---@field lua_language_server_provider? "lua_ls" | "emmylua_ls": Your lua language server provider.
 ---@field path_to_love_bin? string: The path to the Love2D executable
 ---@field restart_on_save? boolean: Restart Love2D when a file is saved
 ---@field debug_window_opts? table: Create split window with Love2D terminal output
@@ -17,35 +19,44 @@ config.options = {}
 ---Setup the LSP for love2d using vim.lsp.config with proper merging
 local function setup_lsp()
   vim.notify("Setting up LÖVE LSP...", vim.log.levels.INFO)
+  local language_server_provider = config.options.lua_language_server_provider
+  if language_server_provider == "lua_ls" or language_server_provider == "emmylua_ls" then
+      -- Configure language server
+      
+      local settings = {
+        Lua = {
+          runtime = { version = "LuaJIT" }, -- LuaJIT 2.1 == Lua 5.1 semantics
+          workspace = { checkThirdParty = false },
+        },
+      }
 
-  local settings = {
-    Lua = {
-      runtime = { version = "LuaJIT" }, -- LuaJIT 2.1 == Lua 5.1 semantics
-      workspace = { checkThirdParty = false },
-    },
-  }
+      if vim.lsp.config[language_server_provider] then
+        settings = vim.tbl_deep_extend("force", vim.lsp.config[language_server_provider].settings or {}, settings)
+      end
 
-  if vim.lsp.config.lua_ls then
-    settings = vim.tbl_deep_extend("force", vim.lsp.config.lua_ls.settings or {}, settings)
+      -- Merge with existing libraries (vim.tbl_deep_extend doesn't work on lists)
+      local libraries = {}
+      if vim.lsp.config[language_server_provider] and vim.lsp.config[language_server_provider].settings and vim.lsp.config[language_server_provider].settings.Lua.workspace then
+        libraries = vim.lsp.config[language_server_provider].settings.Lua.workspace.library or {}
+      end
+      table.insert(libraries, vim.fn.globpath(vim.o.runtimepath, "love2d"))
+      table.insert(libraries, vim.fn.globpath(vim.o.runtimepath, "luasocket"))
+
+      ---@diagnostic disable-next-line: undefined-field
+      settings.Lua.workspace.library = libraries
+
+      -- Apply settings
+      vim.lsp.config(language_server_provider, { settings = settings })
+
+      -- Restart language server provider
+      vim.lsp.enable({ language_server_provider }, false)
+      vim.lsp.enable({ language_server_provider })
+  else
+    vim.notify(
+      "LÖVE2d: Invalid value for option 'lua_language_server_provider'. Refer to documentation for valid values.",
+      vim.log.levels.WARN
+    )
   end
-
-  -- Merge with existing libraries (vim.tbl_deep_extend doesn't work on lists)
-  local libraries = {}
-  if vim.lsp.config.lua_ls and vim.lsp.config.lua_ls.settings and vim.lsp.config.lua_ls.settings.Lua.workspace then
-    libraries = vim.lsp.config.lua_ls.settings.Lua.workspace.library or {}
-  end
-  table.insert(libraries, vim.fn.globpath(vim.o.runtimepath, "love2d"))
-  table.insert(libraries, vim.fn.globpath(vim.o.runtimepath, "luasocket"))
-
-  ---@diagnostic disable-next-line: undefined-field
-  settings.Lua.workspace.library = libraries
-
-  -- Apply settings
-  vim.lsp.config("lua_ls", { settings = settings })
-
-  -- Restart lua_ls
-  vim.lsp.enable({ "lua_ls" }, false)
-  vim.lsp.enable({ "lua_ls" })
 end
 
 ---Setup makeprg and errorformat for Love2D projects


### PR DESCRIPTION
Added support for [emmylua_ls](https://github.com/EmmyLuaLs/emmylua-analyzer-rust), with the addition of a configuration option `lua_language_server_provider` to let the user chose between lua_ls and emmylua_ls.

