### PR TITLE
fix(utils): detect project root without conf.lua

### DIFF
--- a/lua/love2d/utils.lua
+++ b/lua/love2d/utils.lua
@@ -96,7 +96,7 @@ end
 function utils.path_to_main_lua()
   local dir = vim.fn.getcwd()
   while dir do
-    if vim.fn.filereadable(dir .. "/conf.lua") == 1 or vim.fn.isdirectory(dir .. "/.git") == 1 then
+    if is_love2d_root(dir) or vim.fn.isdirectory(dir .. "/.git") == 1 then
       local main = dir .. "/main.lua"
       if vim.fn.filereadable(main) == 1 then
         return main

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -139,6 +139,17 @@ describe("utils", function()
       assert.is_nil(result)
     end)
 
+    it("finds main.lua with love callback but no conf.lua or .git", function()
+      local dir = make_dir("main_cb_only", {
+        ["main.lua"] = "function love.draw() end",
+      })
+      local old_cwd = vim.fn.getcwd()
+      vim.cmd("cd " .. dir)
+      local result = utils.path_to_main_lua()
+      vim.cmd("cd " .. old_cwd)
+      assert.are.equal(vim.fn.resolve(dir .. "/main.lua"), vim.fn.resolve(result or ""))
+    end)
+
     it("returns nil when conf.lua exists but no main.lua", function()
       local dir = make_dir("no_main", {
         ["conf.lua"] = "function love.conf(t) end",


### PR DESCRIPTION
## Problem

`path_to_main_lua` and `path_to_love2d_project` used different logic to find the project root:

- `path_to_love2d_project` — walks up and calls `is_love2d_root`, which checks for LÖVE callbacks/modules in `.lua` files
- `path_to_main_lua` — walked up looking only for `conf.lua` or `.git` as anchors

This mismatch meant that a project with just `main.lua` (no `conf.lua`, no `.git`) would show the "LÖVE project detected" notification (via `path_to_love2d_project`) but then fail with "No LÖVE project detected" on run — because `path_to_main_lua` returned `nil`, and `job.set_project` was never called.

## Fix

Replace the `conf.lua` check in `path_to_main_lua` with `is_love2d_root`, so both functions use the same detection logic. The `.git` anchor is kept as a fallback.